### PR TITLE
Fix admin chart to show item details

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -144,3 +144,24 @@ h1 {
 .logs-table tr:hover {
   background-color: #f9f9f9;
 }
+
+/* Legend for admin chart */
+#legenda {
+  text-align: center;
+  margin-top: 10px;
+}
+
+.legenda-item {
+  display: inline-flex;
+  align-items: center;
+  margin-right: 15px;
+  font-size: 14px;
+}
+
+.legenda-cor {
+  width: 12px;
+  height: 12px;
+  display: inline-block;
+  margin-right: 5px;
+  border-radius: 2px;
+}

--- a/views/painel_admin.html
+++ b/views/painel_admin.html
@@ -43,6 +43,7 @@
       const data = produtos.map(p => p.quantidade);
       const bgColors = produtos.map(p => cores[p.departamento] || 'rgba(75,192,192,0.6)');
 
+      // Grafico detalhado de estoque por produto com cores por departamento
       const ctx = document.getElementById('graficoEstoque');
       new Chart(ctx, {
         type: 'bar',

--- a/views/painel_admin.html
+++ b/views/painel_admin.html
@@ -20,8 +20,9 @@
   </header>
   <main>
     <a href="/" class="back-link">&larr; Início</a>
-    <h1>Estoque por Departamento</h1>
+    <h1>Estoque por Produto</h1>
     <canvas id="graficoEstoque"></canvas>
+    <div id="legenda"></div>
   </main>
 
   <script src="/js/main.js"></script>
@@ -29,22 +30,49 @@
     async function carregarGrafico() {
       const res = await fetch('/api/produtos');
       const produtos = await res.json();
-      const totals = {};
-      produtos.forEach(p => {
-        totals[p.departamento] = (totals[p.departamento] || 0) + p.quantidade;
-      });
+
+      const cores = {
+        Hortifruti: '#7cb5ec',
+        Mercearia: '#f7a35c',
+        Padaria: '#90ed7d',
+        Açougue: '#8085e9',
+        Bebidas: '#f15c80'
+      };
+
+      const labels = produtos.map(p => p.nome);
+      const data = produtos.map(p => p.quantidade);
+      const bgColors = produtos.map(p => cores[p.departamento] || 'rgba(75,192,192,0.6)');
+
       const ctx = document.getElementById('graficoEstoque');
       new Chart(ctx, {
         type: 'bar',
         data: {
-          labels: Object.keys(totals),
+          labels,
           datasets: [{
             label: 'Quantidade',
-            backgroundColor: 'rgba(75,192,192,0.6)',
-            data: Object.values(totals)
+            backgroundColor: bgColors,
+            data
           }]
+        },
+        options: {
+          plugins: {
+            legend: { display: false },
+            tooltip: {
+              callbacks: {
+                label: (context) => {
+                  const produto = produtos[context.dataIndex];
+                  return `${produto.nome} (${produto.departamento}): ${produto.quantidade}`;
+                }
+              }
+            }
+          }
         }
       });
+
+      const legenda = document.getElementById('legenda');
+      legenda.innerHTML = Object.keys(cores).map(dep =>
+        `<span class="legenda-item"><span class="legenda-cor" style="background:${cores[dep]}"></span>${dep}</span>`
+      ).join(' ');
     }
     carregarGrafico();
   </script>

--- a/views/painel_admin.html
+++ b/views/painel_admin.html
@@ -71,7 +71,7 @@
 
       const legenda = document.getElementById('legenda');
       legenda.innerHTML = Object.keys(cores).map(dep =>
-        `<span class="legenda-item"><span class="legenda-cor" style="background:${cores[dep]}"></span>${dep}</span>`
+        `<span class="legenda-item"><span class="legenda-cor" style="background-color:${cores[dep]}"></span>${dep}</span>`
       ).join(' ');
     }
     carregarGrafico();


### PR DESCRIPTION
## Summary
- show item name and department in stock chart tooltip
- display color legend for departments

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6865959420608332be9a507464e27fdc