### PR TITLE
Add Jest testing framework

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node server/server.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "keywords": [],
   "author": "",
@@ -17,5 +17,9 @@
     "cors": "^2.8.5",
     "express": "^5.1.0",
     "sqlite3": "^5.1.7"
+  },
+  "devDependencies": {
+    "jest": "^29.6.0",
+    "supertest": "^6.3.3"
   }
 }

--- a/server/db.js
+++ b/server/db.js
@@ -3,7 +3,9 @@ const path = require('path');
 const bcrypt = require('bcryptjs');
 
 // Caminho do arquivo do banco
-const dbPath = path.resolve(__dirname, 'estoque.sqlite');
+const dbPath = process.env.DB_PATH
+  ? path.resolve(__dirname, process.env.DB_PATH)
+  : path.resolve(__dirname, 'estoque.sqlite');
 
 // Conecta ao banco (cria se não existir)
 const db = new sqlite3.Database(dbPath, (err) => {

--- a/server/server.js
+++ b/server/server.js
@@ -19,7 +19,10 @@ app.use(express.static(path.join(__dirname, '..', 'public')));
 // Rotas
 app.use('/', routes);
 
-// Inicializa o servidor
-app.listen(PORT, () => {
-  console.log(`Servidor rodando em http://localhost:${PORT}`);
-});
+if (require.main === module) {
+  app.listen(PORT, () => {
+    console.log(`Servidor rodando em http://localhost:${PORT}`);
+  });
+}
+
+module.exports = app;

--- a/tests/routes.test.js
+++ b/tests/routes.test.js
@@ -1,0 +1,110 @@
+const request = require('supertest');
+const app = require('./setup');
+
+let token;
+
+beforeAll(async () => {
+  const res = await request(app)
+    .post('/api/login')
+    .send({ email: 'admin', senha: 'admin12345' });
+  token = res.body.token;
+});
+
+describe('Login', () => {
+  test('should login admin user', async () => {
+    const res = await request(app)
+      .post('/api/login')
+      .send({ email: 'admin', senha: 'admin12345' });
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('token');
+  });
+});
+
+describe('Produtos CRUD', () => {
+  let produtoId;
+  const headers = () => ({ 'x-session-token': token });
+
+  test('create produto', async () => {
+    const res = await request(app)
+      .post('/api/produtos')
+      .set(headers())
+      .send({
+        nome: 'Teste',
+        codigo_barras: '123',
+        departamento: 'Bebidas',
+        quantidade: 5,
+        validade: '2030-01-01',
+        preco: 10.5
+      });
+    expect(res.status).toBe(201);
+    expect(res.body).toHaveProperty('id');
+    produtoId = res.body.id;
+  });
+
+  test('get produtos', async () => {
+    const res = await request(app)
+      .get('/api/produtos')
+      .set(headers());
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+  });
+
+  test('update produto', async () => {
+    const res = await request(app)
+      .put(`/api/produtos/${produtoId}`)
+      .set(headers())
+      .send({
+        nome: 'Teste2',
+        departamento: 'Mercearia',
+        quantidade: 8,
+        validade: '2030-06-01',
+        preco: 12.0
+      });
+    expect(res.status).toBe(200);
+  });
+
+  test('delete produto', async () => {
+    const res = await request(app)
+      .delete(`/api/produtos/${produtoId}`)
+      .set(headers());
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('Quebras e Saidas', () => {
+  let produtoId;
+  const headers = () => ({ 'x-session-token': token });
+
+  beforeAll(async () => {
+    const res = await request(app)
+      .post('/api/produtos')
+      .set(headers())
+      .send({
+        nome: 'ProdutoQS',
+        codigo_barras: '999',
+        departamento: 'Teste',
+        quantidade: 10,
+        validade: '2030-12-31',
+        preco: 5.0
+      });
+    produtoId = res.body.id;
+  });
+
+  test('registrar quebra', async () => {
+    const res = await request(app)
+      .post('/api/quebras')
+      .set(headers())
+      .send({ produto_id: produtoId, quantidade: 1, valor_quebra: 2.0 });
+    expect(res.status).toBe(201);
+    expect(res.body).toHaveProperty('id');
+  });
+
+  test('registrar saida', async () => {
+    const res = await request(app)
+      .post('/api/saidas')
+      .set(headers())
+      .send({ produto_id: produtoId, quantidade: 1, valor_saida: 3.0 });
+    expect(res.status).toBe(201);
+    expect(res.body).toHaveProperty('id');
+  });
+});

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,0 +1,7 @@
+const path = require('path');
+process.env.DB_PATH = '../tests/test.sqlite';
+const fs = require('fs');
+const dbFile = path.resolve(__dirname, process.env.DB_PATH);
+if (fs.existsSync(dbFile)) fs.unlinkSync(dbFile);
+const app = require('../server/server');
+module.exports = app;


### PR DESCRIPTION
## Summary
- configure database path through `DB_PATH` env var
- allow server to be imported without starting
- add Jest and Supertest
- write API tests for login, product CRUD and quebra/saida routes
- add npm test script

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865b32e37548332982b191c09dc81ac