### PR TITLE
Use env variables for config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+PORT=3000
+DB_PATH=./server/estoque.sqlite

--- a/README.md
+++ b/README.md
@@ -10,3 +10,14 @@ Sistema simples de controle de estoque com:
 - HTML, CSS, JavaScript
 - Node.js com Express
 - SQLite (banco de dados leve e embutido)
+
+## Configuração
+
+Crie um arquivo `.env` na raiz do projeto baseado em `.env.example` com as seguintes variáveis:
+
+```
+PORT=3000
+DB_PATH=./server/estoque.sqlite
+```
+
+`PORT` define a porta em que o servidor Express irá escutar e `DB_PATH` indica o caminho do arquivo SQLite utilizado pela aplicação.

--- a/loadEnv.js
+++ b/loadEnv.js
@@ -1,0 +1,21 @@
+const fs = require('fs');
+const path = require('path');
+
+function loadEnv() {
+  const envFile = path.resolve(__dirname, '.env');
+  if (!fs.existsSync(envFile)) return;
+  const lines = fs.readFileSync(envFile, 'utf8').split(/\r?\n/);
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eqIndex = trimmed.indexOf('=');
+    if (eqIndex === -1) continue;
+    const key = trimmed.slice(0, eqIndex).trim();
+    const value = trimmed.slice(eqIndex + 1).trim();
+    if (!process.env[key]) {
+      process.env[key] = value;
+    }
+  }
+}
+
+module.exports = loadEnv;

--- a/server/db.js
+++ b/server/db.js
@@ -1,9 +1,14 @@
 const sqlite3 = require('sqlite3').verbose();
 const path = require('path');
 const bcrypt = require('bcryptjs');
+const loadEnv = require('../loadEnv');
+
+// Carrega variáveis de ambiente do arquivo .env se existir
+loadEnv();
 
 // Caminho do arquivo do banco
-const dbPath = path.resolve(__dirname, 'estoque.sqlite');
+const defaultDb = path.resolve(__dirname, 'estoque.sqlite');
+const dbPath = process.env.DB_PATH ? path.resolve(process.env.DB_PATH) : defaultDb;
 
 // Conecta ao banco (cria se não existir)
 const db = new sqlite3.Database(dbPath, (err) => {

--- a/server/server.js
+++ b/server/server.js
@@ -3,10 +3,12 @@ const bodyParser = require('body-parser');
 const cors = require('cors');
 const path = require('path');
 const routes = require('./routes');
+const loadEnv = require('../loadEnv');
+loadEnv();
 const db = require('./db');
 
 const app = express();
-const PORT = 3000;
+const PORT = process.env.PORT || 3000;
 
 // Middleware
 app.use(cors());


### PR DESCRIPTION
## Summary
- add a helper to load variables from `.env`
- configure DB path and server port via env vars
- provide `.env.example`
- document env vars in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6865b331d7c88332820336fe9dfc472b