### PR TITLE
Add reusable form container styling

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -52,6 +52,14 @@ select {
   border-radius: 4px;
 }
 
+.form-container {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-width: 400px;
+  margin: 0 auto;
+}
+
 .back-link {
   display: inline-block;
   margin-bottom: 15px;

--- a/views/admin_criar_usuario.html
+++ b/views/admin_criar_usuario.html
@@ -20,7 +20,7 @@
   <main style="max-width: 400px; margin: auto; padding-top: 60px;">
     <a href="/" class="back-link">&larr; Início</a>
     <h2>Criar Novo Usuário</h2>
-    <form id="form-criar-usuario" style="display: flex; flex-direction: column; gap: 10px;">
+    <form id="form-criar-usuario" class="form-container">
       <input type="text" name="nome" placeholder="Nome" required>
       <input type="email" name="email" placeholder="Email" required>
       <input type="password" name="senha" placeholder="Senha" required>

--- a/views/cadastro.html
+++ b/views/cadastro.html
@@ -23,11 +23,11 @@
   <main>
     <a href="/" class="back-link">&larr; Início</a>
     <h1>Cadastro de Produto</h1>
-    <form id="formCadastro">
-      <input type="text" name="nome" placeholder="Nome do Produto" required><br>
-      <input type="text" name="codigo_barras" placeholder="Código de Barras" required><br>
+    <form id="formCadastro" class="form-container">
+      <input type="text" name="nome" placeholder="Nome do Produto" required>
+      <input type="text" name="codigo_barras" placeholder="Código de Barras" required>
 
-      <label for="departamento">Departamento:</label><br>
+      <label for="departamento">Departamento:</label>
       <select name="departamento" id="departamento" required>
         <option value="">Selecione um departamento</option>
         <option>Hortifruti</option>
@@ -45,13 +45,13 @@
         <option>Congelados</option>
         <option>Produtos Naturais</option>
         <option>Bebê</option>
-      </select><br>
+      </select>
 
-      <input type="number" name="quantidade" placeholder="Quantidade" min="0" required><br>
-      <input type="text" name="preco" id="preco" placeholder="Preço Unitário (R$)" required><br>
-      
-      <label for="validade">Data de Validade:</label><br>
-      <input type="date" id="validade" name="validade"><br>
+      <input type="number" name="quantidade" placeholder="Quantidade" min="0" required>
+      <input type="text" name="preco" id="preco" placeholder="Preço Unitário (R$)" required>
+
+      <label for="validade">Data de Validade:</label>
+      <input type="date" id="validade" name="validade">
 
       <button type="submit">Cadastrar</button>
       <p id="msg-erro" style="color:red"></p>

--- a/views/conferencia_estoque.html
+++ b/views/conferencia_estoque.html
@@ -23,7 +23,7 @@
     <a href="/" class="back-link">&larr; Início</a>
     <h1>Conferência de Estoque</h1>
 
-    <form id="filtros">
+    <form id="filtros" class="form-container">
       <label>Departamento:</label>
       <select name="departamento" id="departamento">
         <option value="">Todos</option>
@@ -58,13 +58,13 @@
 
     <div id="modalEdicao" style="display:none; background:#fff; padding:20px; border:1px solid #ccc; margin-top:20px;">
       <h3>Editar Produto</h3>
-      <form id="formEditar">
+      <form id="formEditar" class="form-container">
         <input type="hidden" id="edit-id">
-        <input type="text" id="edit-nome" placeholder="Nome"><br>
-        <input type="text" id="edit-departamento" placeholder="Departamento"><br>
-        <input type="number" id="edit-quantidade" placeholder="Quantidade"><br>
-        <input type="text" id="edit-preco" placeholder="Preço Unitário (R$)"><br>
-        <input type="date" id="edit-validade"><br>
+        <input type="text" id="edit-nome" placeholder="Nome">
+        <input type="text" id="edit-departamento" placeholder="Departamento">
+        <input type="number" id="edit-quantidade" placeholder="Quantidade">
+        <input type="text" id="edit-preco" placeholder="Preço Unitário (R$)">
+        <input type="date" id="edit-validade">
         <button type="submit">Salvar</button>
         <button type="button" onclick="fecharModal()">Cancelar</button>
       </form>

--- a/views/conferencia_quebras.html
+++ b/views/conferencia_quebras.html
@@ -22,7 +22,7 @@
   <main>
     <a href="/" class="back-link">&larr; Início</a>
     <h1>Conferência de Quebras</h1>
-<form id="filtros">
+<form id="filtros" class="form-container">
   <label>Departamento:</label>
   <select name="departamento"><option value="">Todos</option></select>
   <label>Ano:</label><input type="number" name="ano" min="2000" max="2100">

--- a/views/conferencia_saidas.html
+++ b/views/conferencia_saidas.html
@@ -22,7 +22,7 @@
   <main>
     <a href="/" class="back-link">&larr; Início</a>
     <h1>Conferência de Saídas</h1>
-<form id="filtros">
+<form id="filtros" class="form-container">
   <label>Departamento:</label>
   <select name="departamento"><option value="">Todos</option></select>
   <label>Ano:</label><input type="number" name="ano" min="2000" max="2100">

--- a/views/login.html
+++ b/views/login.html
@@ -9,7 +9,7 @@
   <main style="max-width: 400px; margin: auto; padding-top: 100px;">
     <a href="/" class="back-link">&larr; Início</a>
     <h1 style="text-align: center;">Login</h1>
-    <form id="loginForm" style="display: flex; flex-direction: column; gap: 15px;">
+    <form id="loginForm" class="form-container">
       <input type="email" name="email" placeholder="Email" required>
       <input type="password" name="senha" placeholder="Senha" required>
       <button type="submit">Entrar</button>

--- a/views/quebras.html
+++ b/views/quebras.html
@@ -22,11 +22,11 @@
   <main>
     <a href="/" class="back-link">&larr; Início</a>
     <h1>Registro de Quebras</h1>
-<form id="formQuebra">
-  <label for="produto">Produto:</label><br>
-  <select id="produto" required><option value="">Selecione um produto</option></select><br>
-  <input type="number" name="quantidade" placeholder="Quantidade Quebrada" required><br>
-  <input type="text" name="valor_quebra" id="valor_quebra" placeholder="Valor Total da Quebra (R$)" required><br>
+<form id="formQuebra" class="form-container">
+  <label for="produto">Produto:</label>
+  <select id="produto" required><option value="">Selecione um produto</option></select>
+  <input type="number" name="quantidade" placeholder="Quantidade Quebrada" required>
+  <input type="text" name="valor_quebra" id="valor_quebra" placeholder="Valor Total da Quebra (R$)" required>
   <button type="submit">Registrar Quebra</button>
 </form>
 <script src="/js/main.js"></script>

--- a/views/saidas.html
+++ b/views/saidas.html
@@ -22,11 +22,11 @@
   <main>
     <a href="/" class="back-link">&larr; Início</a>
     <h1>Registro de Saídas</h1>
-<form id="formSaida">
-  <label for="produto">Produto:</label><br>
-  <select id="produto" required><option value="">Selecione um produto</option></select><br>
-  <input type="number" name="quantidade" placeholder="Quantidade Vendida" required><br>
-  <input type="text" name="valor_saida" id="valor_saida" placeholder="Valor Total da Venda (R$)" required><br>
+<form id="formSaida" class="form-container">
+  <label for="produto">Produto:</label>
+  <select id="produto" required><option value="">Selecione um produto</option></select>
+  <input type="number" name="quantidade" placeholder="Quantidade Vendida" required>
+  <input type="text" name="valor_saida" id="valor_saida" placeholder="Valor Total da Venda (R$)" required>
   <button type="submit">Registrar Saída</button>
 </form>
 <script src="/js/main.js"></script>


### PR DESCRIPTION
## Summary
- add new `.form-container` style for flexible vertical forms
- use the new class in all HTML forms
- rely on CSS spacing instead of `<br>` tags

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865ba5a03408332b13059c89185e52c