### PR TITLE
Wrap password change inputs in form

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -165,3 +165,13 @@ h1 {
   margin-right: 5px;
   border-radius: 2px;
 }
+
+/* Generic form layout */
+.form-container {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-width: 400px;
+  margin: auto;
+  padding-top: 60px;
+}

--- a/views/alterar_senha.html
+++ b/views/alterar_senha.html
@@ -17,13 +17,15 @@
     </nav>
     <button onclick="logout()" style="margin-left: auto;">Sair</button>
   </header>
-  <main style="max-width: 400px; margin: auto; padding-top: 60px;">
+  <main>
     <a href="/" class="back-link">&larr; Início</a>
     <h2 style="text-align: center;">Alterar Senha</h2>
-    <input type="password" id="senha_atual" placeholder="Senha Atual" required>
-    <input type="password" id="nova_senha" placeholder="Nova Senha" required>
-    <input type="password" id="confirmar_senha" placeholder="Confirmar Nova Senha" required>
-    <button onclick="alterarSenha()">Salvar Nova Senha</button>
+    <form id="form-alterar-senha" class="form-container">
+      <input type="password" id="senha_atual" placeholder="Senha Atual" required>
+      <input type="password" id="nova_senha" placeholder="Nova Senha" required>
+      <input type="password" id="confirmar_senha" placeholder="Confirmar Nova Senha" required>
+      <button type="submit">Salvar Nova Senha</button>
+    </form>
     <p id="mensagem" style="text-align: center; margin-top: 10px;"></p>
   </main>
 
@@ -62,6 +64,11 @@
       msg.innerText = res.ok ? 'Senha alterada com sucesso!' : (data.erro || 'Erro ao alterar senha');
       msg.style.color = res.ok ? 'green' : 'red';
     }
+
+    document.getElementById('form-alterar-senha').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      await alterarSenha();
+    });
   </script>
   <script>
     const user = JSON.parse(localStorage.getItem('usuarioLogado')) || {};


### PR DESCRIPTION
## Summary
- add generic `.form-container` layout class
- create a form around the password change inputs
- submit the form via JavaScript instead of button click

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865ba69cbfc8332ac446e716bcef072