### PR TITLE
Resolve DB_PATH relative to repo root

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
 PORT=3000
-DB_PATH=./server/estoque.sqlite
+DB_PATH=server/estoque.sqlite

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Crie um arquivo `.env` na raiz do projeto baseado em `.env.example` com as segui
 
 ```
 PORT=3000
-DB_PATH=./server/estoque.sqlite
+DB_PATH=server/estoque.sqlite
 ```
 
 - `PORT` define a porta em que o servidor Express irá escutar.

--- a/server/db.js
+++ b/server/db.js
@@ -7,8 +7,10 @@ const loadEnv = require('../loadEnv');
 loadEnv();
 
 // Caminho do arquivo do banco
+// Se DB_PATH estiver definido, o valor é resolvido relativo à raiz do projeto
+// para permitir definir caminhos fora da pasta `server`
 const dbPath = process.env.DB_PATH
-  ? path.resolve(__dirname, process.env.DB_PATH)
+  ? path.resolve(process.cwd(), process.env.DB_PATH)
   : path.resolve(__dirname, 'estoque.sqlite');
 
 // Conecta ao banco (cria se não existir)

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,5 +1,5 @@
 const path = require('path');
-process.env.DB_PATH = '../tests/test.sqlite';
+process.env.DB_PATH = 'tests/test.sqlite';
 const fs = require('fs');
 const dbFile = path.resolve(__dirname, process.env.DB_PATH);
 if (fs.existsSync(dbFile)) fs.unlinkSync(dbFile);


### PR DESCRIPTION
## Summary
- resolve `DB_PATH` relative to process cwd
- document the new DB_PATH value in README and .env.example
- adjust tests to use new DB_PATH location

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865d764868483329399f7d061898071