### PR TITLE
Use async bcrypt

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -80,18 +80,23 @@ db.serialize(() => {
     if (err) {
       console.error('Erro ao verificar usuário admin:', err.message);
     } else if (!row) {
-      const senhaHash = bcrypt.hashSync('admin12345', 10);
-      db.run(
-        `INSERT INTO usuarios (nome, email, senha_hash, role) VALUES (?, ?, ?, ?)`,
-        ['Administrador', 'admin', senhaHash, 'admin'],
-        (err) => {
-          if (err) {
-            console.error('Erro ao inserir usuário admin:', err.message);
-          } else {
-            console.log('Usuário admin padrão criado (senha: admin12345)');
-          }
+      bcrypt.hash('admin12345', 10, (err, senhaHash) => {
+        if (err) {
+          console.error('Erro ao gerar hash da senha admin:', err.message);
+          return;
         }
-      );
+        db.run(
+          `INSERT INTO usuarios (nome, email, senha_hash, role) VALUES (?, ?, ?, ?)`,
+          ['Administrador', 'admin', senhaHash, 'admin'],
+          (err) => {
+            if (err) {
+              console.error('Erro ao inserir usuário admin:', err.message);
+            } else {
+              console.log('Usuário admin padrão criado (senha: admin12345)');
+            }
+          }
+        );
+      });
     }
   });
 });


### PR DESCRIPTION
## Summary
- use async `bcrypt.compare` in login route
- use async `bcrypt.hash` when creating users
- use async `bcrypt.hash`/`compare` in password change route
- generate default admin password hash asynchronously

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865db688cf483328b995e389a95d56b