### PR TITLE
Use async password hashing for admin creation

### DIFF
--- a/server/criarAdmin.js
+++ b/server/criarAdmin.js
@@ -5,16 +5,21 @@ const email = 'admin@admin.com';
 const nome = 'Administrador';
 const senha = 'admin12345';
 const role = 'admin';
-const senhaHash = bcrypt.hashSync(senha, 10);
-
-db.run(
-  `INSERT INTO usuarios (nome, email, senha_hash, role) VALUES (?, ?, ?, ?)`,
-  [nome, email, senhaHash, role],
-  (err) => {
-    if (err) {
-      console.error('Erro ao inserir usuário admin:', err.message);
-    } else {
-      console.log('Usuário admin criado com sucesso.');
-    }
+bcrypt.hash(senha, 10, (hashErr, senhaHash) => {
+  if (hashErr) {
+    console.error('Erro ao gerar hash da senha admin:', hashErr.message);
+    return;
   }
-);
+
+  db.run(
+    `INSERT INTO usuarios (nome, email, senha_hash, role) VALUES (?, ?, ?, ?)`,
+    [nome, email, senhaHash, role],
+    (err) => {
+      if (err) {
+        console.error('Erro ao inserir usuário admin:', err.message);
+      } else {
+        console.log('Usuário admin criado com sucesso.');
+      }
+    }
+  );
+});


### PR DESCRIPTION
## Summary
- swap `bcrypt.hashSync` for async `bcrypt.hash`
- handle async callback when inserting the admin

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865e49c9624833293b279d7b63dc464