### PR TITLE
Remove incompatible xss-clean middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Sistema simples de controle de estoque com:
 - HTML, CSS, JavaScript
 - Node.js com Express
 - SQLite (banco de dados leve e embutido)
+- A sanitização básica dos campos é feita manualmente em `server/routes.js`. O middleware `xss-clean` foi removido por incompatibilidade com o Express 5.
 
 ## Configuração
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,7 @@
         "body-parser": "^2.2.0",
         "cors": "^2.8.5",
         "express": "^5.1.0",
-        "sqlite3": "^5.1.7",
-        "xss-clean": "^0.1.1",
-        "xss-filters": "^1.2.7"
+        "sqlite3": "^5.1.7"
       },
       "devDependencies": {
         "jest": "^29.6.0",
@@ -5760,13 +5758,10 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
-    "node_modules/xss-clean": {
       "version": "0.1.1",
       "license": "MIT"
     },
-    "node_modules/xss-filters": {
       "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/xss-filters/-/xss-filters-1.2.7.tgz",
       "integrity": "sha512-KzcmYT/f+YzcYrYRqw6mXxd25BEZCxBQnf+uXTopQDIhrmiaLwO+f+yLsIvvNlPhYvgff8g3igqrBxYh9k8NbQ=="
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -16,9 +16,7 @@
     "body-parser": "^2.2.0",
     "cors": "^2.8.5",
     "express": "^5.1.0",
-    "sqlite3": "^5.1.7",
-    "xss-clean": "^0.1.1",
-    "xss-filters": "^1.2.7"
+    "sqlite3": "^5.1.7"
   },
   "devDependencies": {
     "jest": "^29.6.0",

--- a/server/server.js
+++ b/server/server.js
@@ -1,7 +1,6 @@
 const express = require('express');
 const bodyParser = require('body-parser');
 const cors = require('cors');
-const xssClean = require('xss-clean');
 const path = require('path');
 const routes = require('./routes');
 const loadEnv = require('../loadEnv');
@@ -16,7 +15,6 @@ const PORT = process.env.PORT || 3000;
 app.use(cors());
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true }));
-app.use(xssClean());
 app.use(session({ cookie: { maxAge: 60 * 60 * 1000 } }));
 
 // Servir arquivos estáticos


### PR DESCRIPTION
## Summary
- drop the xss-clean dependency which broke on Express 5
- update package-lock accordingly
- remove usage from server.js
- document manual sanitization in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865eccad2c08332afecc3e144fd06ba