### PR TITLE
Implementa baixa de estoque em quebras e saídas

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ node server/criarAdmin.js
 - `GET /api/notificacoes/validade` – lista produtos que vencem em até 20 dias.
 - `GET /api/departamentos/resumo` – valores de estoque, quebras e saídas por departamento.
 - `GET /api/logs` – lista logs (admin).
+- Ao registrar uma quebra ou saída a API verifica se o produto possui quantidade
+  suficiente. Caso contrário, o pedido é recusado com status 400. Quando o
+  registro é criado com sucesso a quantidade do produto é reduzida.
 
 ### Estilo de formulários
 

--- a/tests/routes.test.js
+++ b/tests/routes.test.js
@@ -85,6 +85,10 @@ describe('Quebras e Saidas', () => {
       .send({ produto_id: produtoId, quantidade: 1, valor_quebra: 2.0 });
     expect(res.status).toBe(201);
     expect(res.body).toHaveProperty('id');
+
+    const prodRes = await agent.get('/api/produtos');
+    const produto = prodRes.body.find((p) => p.id === produtoId);
+    expect(produto.quantidade).toBe(9);
   });
 
   test('registrar saida', async () => {
@@ -93,6 +97,10 @@ describe('Quebras e Saidas', () => {
       .send({ produto_id: produtoId, quantidade: 1, valor_saida: 3.0 });
     expect(res.status).toBe(201);
     expect(res.body).toHaveProperty('id');
+
+    const prodRes = await agent.get('/api/produtos');
+    const produto = prodRes.body.find((p) => p.id === produtoId);
+    expect(produto.quantidade).toBe(8);
   });
 });
 


### PR DESCRIPTION
## Resumo
- verifica quantidade antes de registrar quebras e saídas
- reduz a quantidade do produto após registrar
- testa atualização de estoque nos registros
- documenta a regra de baixa de estoque

## Testes
- `npm test` *(falha: jest não encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_6865fa674ec883328f9f14ddc457a065