### PR TITLE
Atualiza README sobre uso de npm install antes dos testes

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,18 @@ uniformes.
 
 ## Testes
 
-Quando os testes forem implementados, execute-os com:
+Antes de rodar a suíte de testes, certifique-se de que todas as dependências
+(inclusive as de desenvolvimento) estão instaladas:
+
+```bash
+npm install
+```
+
+Em seguida execute:
 
 ```bash
 npm test
 ```
+
+Para ambientes de automação (como pipelines de CI/CD) recomenda-se criar um
+script de setup que execute o `npm install` antes de rodar os testes.


### PR DESCRIPTION
## Summary
- documente que npm install deve ser executado antes dos testes
- sugira script de setup para pipelines de automação

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865fc467aec8332839ff9e2f4cc5273