### PR TITLE
Add supplier management

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -24,6 +24,17 @@ const db = new sqlite3.Database(dbPath, (err) => {
 
 // Criação das tabelas
 db.serialize(() => {
+  // Fornecedores
+  db.run(`CREATE TABLE IF NOT EXISTS fornecedores (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    nome TEXT NOT NULL,
+    cnpj TEXT,
+    telefone TEXT,
+    email TEXT,
+    endereco TEXT,
+    data_inicio DATE
+  )`);
+
   // Produtos
   db.run(`CREATE TABLE IF NOT EXISTS produtos (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -33,7 +44,9 @@ db.serialize(() => {
     quantidade INTEGER DEFAULT 0,
     validade DATE,
     preco REAL,
-    data_entrada DATE DEFAULT CURRENT_DATE
+    data_entrada DATE DEFAULT CURRENT_DATE,
+    fornecedor_id INTEGER,
+    FOREIGN KEY (fornecedor_id) REFERENCES fornecedores(id)
   )`);
 
   // Quebras

--- a/tests/routes.test.js
+++ b/tests/routes.test.js
@@ -154,3 +154,45 @@ describe('Resumo por departamento', () => {
     expect(dep.valor_saidas).toBe(5);
   });
 });
+
+describe('Fornecedores CRUD', () => {
+  let fornecedorId;
+
+  test('criar fornecedor', async () => {
+    const res = await agent.post('/api/fornecedores').send({
+      nome: 'Fornecedor Teste',
+      cnpj: '00',
+      telefone: '1111',
+      email: 'f@teste',
+      endereco: 'Rua 1',
+      data_inicio: '2023-01-01'
+    });
+    expect(res.status).toBe(201);
+    fornecedorId = res.body.id;
+    expect(fornecedorId).toBeDefined();
+  });
+
+  test('listar fornecedores', async () => {
+    const res = await agent.get('/api/fornecedores');
+    expect(res.status).toBe(200);
+    const forn = res.body.find((f) => f.id === fornecedorId);
+    expect(forn).toBeDefined();
+  });
+
+  test('atualizar fornecedor', async () => {
+    const res = await agent.put(`/api/fornecedores/${fornecedorId}`).send({
+      nome: 'Fornecedor Editado',
+      cnpj: '11',
+      telefone: '2222',
+      email: 'f@edit',
+      endereco: 'Rua 2',
+      data_inicio: '2023-02-01'
+    });
+    expect(res.status).toBe(200);
+  });
+
+  test('excluir fornecedor', async () => {
+    const res = await agent.delete(`/api/fornecedores/${fornecedorId}`);
+    expect(res.status).toBe(200);
+  });
+});

--- a/views/fornecedores.html
+++ b/views/fornecedores.html
@@ -1,0 +1,169 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <title>Fornecedores</title>
+  <link rel="stylesheet" href="/css/style.css">
+</head>
+<body>
+  <header>
+    <div><strong>Estoque do Supermercado</strong></div>
+    <nav>
+      <a href="/conferencia-estoque">📋 Conferência de Estoque</a>
+      <a href="/conferencia-quebras">📉 Conferência de Quebras</a>
+      <a href="/conferencia-saidas">📈 Conferência de Saídas</a>
+      <a href="/alterar-senha">🔐 Alterar Senha</a>
+      <span id="links-admin"></span>
+    </nav>
+    <button onclick="logout()" class="logout-btn">Sair</button>
+  </header>
+  <main>
+    <a href="/" class="back-link">&larr; Início</a>
+    <h1>Fornecedores</h1>
+    <form id="formFornecedor" class="form-container">
+      <div class="form-group"><input type="text" name="nome" placeholder="Nome" required></div>
+      <div class="form-group"><input type="text" name="cnpj" placeholder="CNPJ"></div>
+      <div class="form-group"><input type="text" name="telefone" placeholder="Telefone"></div>
+      <div class="form-group"><input type="email" name="email" placeholder="Email"></div>
+      <div class="form-group"><input type="text" name="endereco" placeholder="Endereço"></div>
+      <div class="form-group"><label for="data_inicio">Início:</label><input type="date" name="data_inicio"></div>
+      <div class="form-group"><button type="submit">Criar</button></div>
+    </form>
+    <table>
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Nome</th>
+          <th>CNPJ</th>
+          <th>Telefone</th>
+          <th>Email</th>
+          <th>Endereço</th>
+          <th>Início</th>
+          <th>Produtos</th>
+          <th>Ações</th>
+        </tr>
+      </thead>
+      <tbody id="tabela"></tbody>
+    </table>
+    <div id="modalEditar" style="display:none; background:#fff; padding:20px; border:1px solid #ccc; margin-top:20px;">
+      <h3>Editar Fornecedor</h3>
+      <form id="formEditar" class="form-container">
+        <input type="hidden" id="edit-id">
+        <div class="form-group"><input type="text" id="edit-nome" placeholder="Nome"></div>
+        <div class="form-group"><input type="text" id="edit-cnpj" placeholder="CNPJ"></div>
+        <div class="form-group"><input type="text" id="edit-telefone" placeholder="Telefone"></div>
+        <div class="form-group"><input type="email" id="edit-email" placeholder="Email"></div>
+        <div class="form-group"><input type="text" id="edit-endereco" placeholder="Endereço"></div>
+        <div class="form-group"><input type="date" id="edit-inicio"></div>
+        <div class="form-group">
+          <button type="submit">Salvar</button>
+          <button type="button" onclick="fecharModal()">Cancelar</button>
+        </div>
+      </form>
+    </div>
+  </main>
+  <script src="/js/main.js"></script>
+  <script>
+    async function carregar() {
+      const res = await fetch('/api/fornecedores');
+      const fornecedores = await res.json();
+      const tbody = document.getElementById('tabela');
+      tbody.innerHTML = '';
+      fornecedores.forEach(f => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `
+          <td>${f.id}</td>
+          <td>${f.nome}</td>
+          <td>${f.cnpj || ''}</td>
+          <td>${f.telefone || ''}</td>
+          <td>${f.email || ''}</td>
+          <td>${f.endereco || ''}</td>
+          <td>${f.data_inicio || ''}</td>
+          <td>${f.produtos.join(', ')}</td>
+          <td><button onclick="editar(${f.id})">Editar</button> <button onclick="deletar(${f.id})">Excluir</button></td>`;
+        tbody.appendChild(tr);
+      });
+    }
+
+    document.getElementById('formFornecedor').addEventListener('submit', async e => {
+      e.preventDefault();
+      const dados = Object.fromEntries(new FormData(e.target));
+      const res = await fetch('/api/fornecedores', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(dados)
+      });
+      if (res.ok) {
+        e.target.reset();
+        carregar();
+      } else {
+        alert('Erro ao criar fornecedor');
+      }
+    });
+
+    async function deletar(id) {
+      if (!confirm('Excluir fornecedor?')) return;
+      const res = await fetch('/api/fornecedores/' + id, { method: 'DELETE' });
+      if (res.ok) carregar();
+      else alert('Erro');
+    }
+
+    function editar(id) {
+      const row = Array.from(document.querySelectorAll('#tabela tr')).find(r => r.firstChild.textContent == id);
+      if (!row) return;
+      document.getElementById('edit-id').value = id;
+      document.getElementById('edit-nome').value = row.children[1].textContent;
+      document.getElementById('edit-cnpj').value = row.children[2].textContent;
+      document.getElementById('edit-telefone').value = row.children[3].textContent;
+      document.getElementById('edit-email').value = row.children[4].textContent;
+      document.getElementById('edit-endereco').value = row.children[5].textContent;
+      document.getElementById('edit-inicio').value = row.children[6].textContent;
+      document.getElementById('modalEditar').style.display = 'block';
+    }
+
+    function fecharModal() {
+      document.getElementById('modalEditar').style.display = 'none';
+    }
+
+    document.getElementById('formEditar').addEventListener('submit', async e => {
+      e.preventDefault();
+      const id = document.getElementById('edit-id').value;
+      const dados = {
+        nome: document.getElementById('edit-nome').value,
+        cnpj: document.getElementById('edit-cnpj').value,
+        telefone: document.getElementById('edit-telefone').value,
+        email: document.getElementById('edit-email').value,
+        endereco: document.getElementById('edit-endereco').value,
+        data_inicio: document.getElementById('edit-inicio').value
+      };
+      const res = await fetch('/api/fornecedores/' + id, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(dados)
+      });
+      if (res.ok) {
+        fecharModal();
+        carregar();
+      } else {
+        alert('Erro ao atualizar');
+      }
+    });
+
+    carregar();
+
+    const user = JSON.parse(localStorage.getItem('usuarioLogado')) || {};
+    const linksAdmin = document.getElementById('links-admin');
+    if (user.role === 'admin') {
+      linksAdmin.innerHTML = `
+        <a href="/cadastro">📦 Cadastro</a>
+        <a href="/quebras">❌ Quebras</a>
+        <a href="/saidas">💰 Saídas</a>
+        <a href="/fornecedores">🚚 Fornecedores</a>
+        <a href="/logs">🕵️ Logs</a>
+        <a href="/painel-admin">📊 Painel</a>
+        <a href="/admin-criar-usuario">👤 Novo Usuário</a>
+      `;
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `fornecedores` table and link it to produtos
- expose fornecedores CRUD and reporting endpoints
- store fornecedor_id for each produto
- new admin page to manage suppliers
- test fornecedor API

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686602e2406883328c423c64dcb05dbe