### PR TITLE
Add Brazilian price parser

### DIFF
--- a/server/priceUtils.js
+++ b/server/priceUtils.js
@@ -1,0 +1,17 @@
+function parsePrecoBR(valor) {
+  if (valor === null || valor === undefined) return NaN;
+  const str = String(valor).trim();
+  if (!str) return NaN;
+
+  const regexMilhar = /^\d{1,3}(\.\d{3})*(,\d+)?$/;
+  const regexSimples = /^\d+(,\d+)?$/;
+  if (!regexMilhar.test(str) && !regexSimples.test(str)) {
+    return NaN;
+  }
+
+  const normalized = str.replace(/\./g, '').replace(',', '.');
+  const num = parseFloat(normalized);
+  return isNaN(num) ? NaN : num;
+}
+
+module.exports = { parsePrecoBR };

--- a/server/routes.js
+++ b/server/routes.js
@@ -4,6 +4,7 @@ const db = require('./db');
 const path = require('path');
 const bcrypt = require('bcryptjs');
 const cookie = require('cookie');
+const { parsePrecoBR } = require('./priceUtils');
 let transporter = null;
 if (process.env.EMAIL_HOST) {
   try {
@@ -220,7 +221,7 @@ router.post('/api/produtos', authMiddleware, adminMiddleware, (req, res) => {
   }
 
   const qtd = parseInt(quantidade, 10) || 0;
-  const precoNum = parseFloat(String(preco).replace(/[R$\s\.]/g, '').replace(',', '.'));
+  const precoNum = parsePrecoBR(preco);
   if (isNaN(precoNum)) {
     return res.status(400).json({ erro: 'Preço inválido' });
   }
@@ -263,7 +264,7 @@ router.put('/api/produtos/:id', authMiddleware, adminMiddleware, (req, res) => {
   const { nome, departamento, quantidade, preco, validade, fornecedor_id, estoque_minimo } = req.body;
   const { id } = req.params;
   const qtd = parseInt(quantidade, 10) || 0;
-  const precoNum = parseFloat(String(preco).replace(/[R$\s\.]/g, '').replace(',', '.'));
+  const precoNum = parsePrecoBR(preco);
   if (isNaN(precoNum)) {
     return res.status(400).json({ erro: 'Preço inválido' });
   }
@@ -363,7 +364,7 @@ router.get('/api/produtos/:id/movimentacoes', authMiddleware, (req, res) => {
 router.post('/api/quebras', authMiddleware, adminMiddleware, (req, res) => {
   const { produto_id, quantidade, valor_quebra } = req.body;
   const qtd = parseInt(quantidade, 10) || 0;
-  const valorNum = parseFloat(String(valor_quebra).replace(/[R$\s\.]/g, '').replace(',', '.')) || 0;
+  const valorNum = parsePrecoBR(valor_quebra);
 
   db.get('SELECT quantidade FROM produtos WHERE id = ?', [produto_id], (err, row) => {
     if (err) return res.status(500).json({ erro: err.message });
@@ -418,7 +419,7 @@ router.put('/api/quebras/:id', authMiddleware, adminMiddleware, (req, res) => {
   const { id } = req.params;
   const { produto_id, quantidade, valor_quebra, data_quebra } = req.body;
   const qtd = parseInt(quantidade, 10) || 0;
-  const valorNum = parseFloat(String(valor_quebra).replace(/[R$\s\.]/g, '').replace(',', '.')) || 0;
+  const valorNum = parsePrecoBR(valor_quebra);
   const sql = `UPDATE quebras SET produto_id = ?, quantidade = ?, valor_quebra = ?, data_quebra = ? WHERE id = ?`;
   db.run(sql, [produto_id, qtd, valorNum, data_quebra, id], function (err) {
     if (err) return res.status(500).json({ erro: err.message });
@@ -443,7 +444,7 @@ router.delete('/api/quebras/:id', authMiddleware, adminMiddleware, (req, res) =>
 router.post('/api/saidas', authMiddleware, adminMiddleware, (req, res) => {
   const { produto_id, quantidade, valor_saida } = req.body;
   const qtd = parseInt(quantidade, 10) || 0;
-  const valorNum = parseFloat(String(valor_saida).replace(/[R$\s\.]/g, '').replace(',', '.')) || 0;
+  const valorNum = parsePrecoBR(valor_saida);
 
   db.get('SELECT quantidade FROM produtos WHERE id = ?', [produto_id], (err, row) => {
     if (err) return res.status(500).json({ erro: err.message });
@@ -498,7 +499,7 @@ router.put('/api/saidas/:id', authMiddleware, adminMiddleware, (req, res) => {
   const { id } = req.params;
   const { produto_id, quantidade, valor_saida, data_saida } = req.body;
   const qtd = parseInt(quantidade, 10) || 0;
-  const valorNum = parseFloat(String(valor_saida).replace(/[R$\s\.]/g, '').replace(',', '.')) || 0;
+  const valorNum = parsePrecoBR(valor_saida);
   const sql = `UPDATE saidas SET produto_id = ?, quantidade = ?, valor_saida = ?, data_saida = ? WHERE id = ?`;
   db.run(sql, [produto_id, qtd, valorNum, data_saida, id], function (err) {
     if (err) return res.status(500).json({ erro: err.message });

--- a/tests/routes.test.js
+++ b/tests/routes.test.js
@@ -30,7 +30,7 @@ describe('Produtos CRUD', () => {
         departamento: 'Bebidas',
         quantidade: 5,
         validade: '2030-01-01',
-        preco: 10.5
+        preco: "10,5"
       });
     expect(res.status).toBe(201);
     expect(res.body).toHaveProperty('id');
@@ -51,7 +51,7 @@ describe('Produtos CRUD', () => {
         departamento: 'Mercearia',
         quantidade: 8,
         validade: '2030-06-01',
-        preco: 12.0
+        preco: "12"
       });
     expect(res.status).toBe(200);
   });
@@ -80,7 +80,7 @@ describe('Quebras e Saidas', () => {
         departamento: 'Teste',
         quantidade: 10,
         validade: '2030-12-31',
-        preco: 5.0
+        preco: "5"
       });
     produtoId = res.body.id;
   });
@@ -88,7 +88,7 @@ describe('Quebras e Saidas', () => {
   test('registrar quebra', async () => {
     const res = await agent
       .post('/api/quebras')
-      .send({ produto_id: produtoId, quantidade: 1, valor_quebra: 2.0 });
+      .send({ produto_id: produtoId, quantidade: 1, valor_quebra: "2" });
     expect(res.status).toBe(201);
     expect(res.body).toHaveProperty('id');
 
@@ -100,7 +100,7 @@ describe('Quebras e Saidas', () => {
   test('registrar saida', async () => {
     const res = await agent
       .post('/api/saidas')
-      .send({ produto_id: produtoId, quantidade: 1, valor_saida: 3.0 });
+      .send({ produto_id: produtoId, quantidade: 1, valor_saida: "3" });
     expect(res.status).toBe(201);
     expect(res.body).toHaveProperty('id');
 
@@ -135,7 +135,7 @@ describe('Notificações de validade', () => {
       departamento: 'Teste',
       quantidade: 2,
       validade: validadeProxima,
-      preco: 1.0,
+      preco: "1",
     });
     produtoId = res.body.id;
   });
@@ -220,7 +220,7 @@ describe('Alertas de Ruptura', () => {
       quantidade: 3,
       estoque_minimo: 2,
       validade: '2030-01-01',
-      preco: 1.0
+      preco: "1"
     });
     produtoId = res.body.id;
   });
@@ -250,7 +250,7 @@ describe('Alertas de Ruptura', () => {
       nome: 'Ruptura',
       departamento: 'Teste',
       quantidade: 5,
-      preco: 1.0,
+      preco: "1",
       validade: '2030-01-01',
       fornecedor_id: null,
       estoque_minimo: 2


### PR DESCRIPTION
## Summary
- parse Brazilian price strings via new `parsePrecoBR` utility
- use `parsePrecoBR` when reading product, breakage and sale prices
- update tests to send prices in Brazilian format

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866b405e90c8332b6cb938dc5f42d47