### PR TITLE
Implementa utilitário de formatação de preços

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -16,3 +16,11 @@
     window.location.href = '/login';
   };
 })();
+
+// Formata valores numéricos como preço em reais
+function formatarPreco(valor) {
+  return new Intl.NumberFormat('pt-BR', {
+    style: 'currency',
+    currency: 'BRL'
+  }).format(valor);
+}

--- a/views/cadastro.html
+++ b/views/cadastro.html
@@ -73,9 +73,8 @@
 
       inputPreco.addEventListener('input', () => {
         let v = inputPreco.value.replace(/\D/g, '');
-        v = (parseFloat(v) / 100).toFixed(2) + '';
-        v = v.replace('.', ',');
-        inputPreco.value = 'R$ ' + v;
+        v = parseFloat(v) / 100;
+        inputPreco.value = formatarPreco(v);
       });
 
       document.getElementById('formCadastro').addEventListener('submit', async (e) => {

--- a/views/conferencia_estoque.html
+++ b/views/conferencia_estoque.html
@@ -108,7 +108,7 @@
           <td>${p.nome}</td>
           <td>${p.departamento}</td>
           <td>${p.quantidade}</td>
-          <td>R$ ${Number(p.preco).toFixed(2)}</td>
+          <td>${formatarPreco(p.preco)}</td>
           <td>${p.validade || '-'}</td>
           <td>${p.data_entrada || '-'}</td>
           <td>
@@ -142,7 +142,7 @@
       document.getElementById('edit-nome').value = decodeURIComponent(nome);
       document.getElementById('edit-departamento').value = decodeURIComponent(departamento);
       document.getElementById('edit-quantidade').value = quantidade;
-      document.getElementById('edit-preco').value = 'R$ ' + Number(preco).toFixed(2).replace('.', ',');
+      document.getElementById('edit-preco').value = formatarPreco(preco);
       document.getElementById('edit-validade').value = decodeURIComponent(validade);
       document.getElementById('modalEdicao').style.display = 'block';
     }
@@ -157,9 +157,8 @@
 
     document.getElementById('edit-preco').addEventListener('input', e => {
       let v = e.target.value.replace(/\D/g, '');
-      v = (parseFloat(v) / 100).toFixed(2);
-      v = v.replace('.', ',');
-      e.target.value = 'R$ ' + v;
+      v = parseFloat(v) / 100;
+      e.target.value = formatarPreco(v);
     });
 
     document.getElementById('formEditar').addEventListener('submit', async (e) => {

--- a/views/conferencia_quebras.html
+++ b/views/conferencia_quebras.html
@@ -77,7 +77,7 @@
             <td>${q.produto}</td>
             <td>${q.departamento}</td>
             <td>${q.quantidade}</td>
-            <td>R$ ${Number(q.valor_quebra).toFixed(2)}</td>
+          <td>${formatarPreco(q.valor_quebra)}</td>
             <td>${q.data_quebra}</td>
           `;
           tbody.appendChild(tr);

--- a/views/conferencia_saidas.html
+++ b/views/conferencia_saidas.html
@@ -77,7 +77,7 @@
             <td>${s.produto}</td>
             <td>${s.departamento}</td>
             <td>${s.quantidade}</td>
-            <td>R$ ${Number(s.valor_saida).toFixed(2)}</td>
+          <td>${formatarPreco(s.valor_saida)}</td>
             <td>${s.data_saida}</td>
           `;
           tbody.appendChild(tr);

--- a/views/quebras.html
+++ b/views/quebras.html
@@ -57,9 +57,8 @@
 
       document.getElementById('valor_quebra').addEventListener('input', e => {
         let v = e.target.value.replace(/\D/g, '');
-        v = (parseFloat(v) / 100).toFixed(2);
-        v = v.replace('.', ',');
-        e.target.value = 'R$ ' + v;
+        v = parseFloat(v) / 100;
+        e.target.value = formatarPreco(v);
       });
 
       document.getElementById('formQuebra').addEventListener('submit', async (e) => {

--- a/views/saidas.html
+++ b/views/saidas.html
@@ -58,9 +58,8 @@
 
       document.getElementById('valor_saida').addEventListener('input', e => {
         let v = e.target.value.replace(/\D/g, '');
-        v = (parseFloat(v) / 100).toFixed(2);
-        v = v.replace('.', ',');
-        e.target.value = 'R$ ' + v;
+        v = parseFloat(v) / 100;
+        e.target.value = formatarPreco(v);
       });
 
       document.getElementById('formSaida').addEventListener('submit', async (e) => {


### PR DESCRIPTION
## Summary
- adicionar função `formatarPreco` em JavaScript global
- usar `formatarPreco` nas páginas de conferência de estoque, quebras e saídas
- formatar campos de preço em formulários com `formatarPreco`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866b63416348332b85cd8a07ee65757