### PR TITLE
Implement date formatting helpers

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -24,3 +24,15 @@ function formatarPreco(valor) {
     currency: 'BRL'
   }).format(valor);
 }
+
+// Formata datas no formato brasileiro (dd/mm/aaaa)
+function formatarDataISO(iso) {
+  if (!iso) return '';
+  return new Date(iso).toLocaleDateString('pt-BR');
+}
+
+// Formata datas e horas no formato brasileiro (dd/mm/aaaa hh:mm:ss)
+function formatarDataHoraISO(iso) {
+  if (!iso) return '';
+  return new Date(iso).toLocaleString('pt-BR');
+}

--- a/views/conferencia_estoque.html
+++ b/views/conferencia_estoque.html
@@ -109,8 +109,8 @@
           <td>${p.departamento}</td>
           <td>${p.quantidade}</td>
           <td>${formatarPreco(p.preco)}</td>
-          <td>${p.validade || '-'}</td>
-          <td>${p.data_entrada || '-'}</td>
+          <td>${p.validade ? formatarDataISO(p.validade) : '-'}</td>
+          <td>${p.data_entrada ? formatarDataISO(p.data_entrada) : '-'}</td>
           <td>
             <button onclick="editarProduto(${p.id}, '${nome}', '${departamento}', ${p.quantidade}, ${p.preco}, '${validade}')">✏️ Editar</button>
             <button onclick="deletarProduto(${p.id})">🗑️ Excluir</button>

--- a/views/conferencia_quebras.html
+++ b/views/conferencia_quebras.html
@@ -78,7 +78,7 @@
             <td>${q.departamento}</td>
             <td>${q.quantidade}</td>
           <td>${formatarPreco(q.valor_quebra)}</td>
-            <td>${q.data_quebra}</td>
+            <td>${formatarDataISO(q.data_quebra)}</td>
           `;
           tbody.appendChild(tr);
         });

--- a/views/conferencia_saidas.html
+++ b/views/conferencia_saidas.html
@@ -78,7 +78,7 @@
             <td>${s.departamento}</td>
             <td>${s.quantidade}</td>
           <td>${formatarPreco(s.valor_saida)}</td>
-            <td>${s.data_saida}</td>
+            <td>${formatarDataISO(s.data_saida)}</td>
           `;
           tbody.appendChild(tr);
         });

--- a/views/fornecedores.html
+++ b/views/fornecedores.html
@@ -78,7 +78,7 @@
           <td>${f.telefone || ''}</td>
           <td>${f.email || ''}</td>
           <td>${f.endereco || ''}</td>
-          <td>${f.data_inicio || ''}</td>
+          <td data-iso="${f.data_inicio || ''}">${f.data_inicio ? formatarDataISO(f.data_inicio) : ''}</td>
           <td>${f.produtos.join(', ')}</td>
           <td><button onclick="editar(${f.id})">Editar</button> <button onclick="deletar(${f.id})">Excluir</button></td>`;
         tbody.appendChild(tr);
@@ -117,7 +117,7 @@
       document.getElementById('edit-telefone').value = row.children[3].textContent;
       document.getElementById('edit-email').value = row.children[4].textContent;
       document.getElementById('edit-endereco').value = row.children[5].textContent;
-      document.getElementById('edit-inicio').value = row.children[6].textContent;
+      document.getElementById('edit-inicio').value = row.children[6].dataset.iso;
       document.getElementById('modalEditar').style.display = 'block';
     }
 

--- a/views/movimentacoes.html
+++ b/views/movimentacoes.html
@@ -44,7 +44,7 @@
       tbody.innerHTML = '';
       movs.forEach(m => {
         const tr = document.createElement('tr');
-        tr.innerHTML = `<td>${m.acao}</td><td>${m.quantidade}</td><td>${m.data}</td><td>${m.usuario}</td>`;
+        tr.innerHTML = `<td>${m.acao}</td><td>${m.quantidade}</td><td>${formatarDataISO(m.data)}</td><td>${m.usuario}</td>`;
         tbody.appendChild(tr);
       });
     }

--- a/views/painel_admin.html
+++ b/views/painel_admin.html
@@ -129,7 +129,7 @@
         if (d.length) {
           const div = document.getElementById('validade-alert');
           div.innerHTML = `<h2>Produtos próximos do vencimento</h2><ul>` +
-            d.map(p => `<li>${p.nome} - ${p.quantidade} un. vence em ${p.validade}</li>`).join('') +
+            d.map(p => `<li>${p.nome} - ${p.quantidade} un. vence em ${formatarDataISO(p.validade)}</li>`).join('') +
             `</ul>`;
         }
       });

--- a/views/painel_logs.html
+++ b/views/painel_logs.html
@@ -46,7 +46,7 @@
     logs.forEach(log => {
       const tr = document.createElement('tr');
       tr.innerHTML = `
-        <td>${log.data_hora}</td>
+        <td>${formatarDataHoraISO(log.data_hora)}</td>
         <td>${log.usuario}</td>
         <td>${log.acao}</td>
         <td>${log.detalhes}</td>


### PR DESCRIPTION
## Summary
- add `formatarDataISO` and `formatarDataHoraISO` helpers
- apply date formatting across conference views and admin panel
- use dataset for fornecedor edit form

## Testing
- `npm test` *(fails: jest not found)*
- `npx jest` *(fails: network access disabled)*

------
https://chatgpt.com/codex/tasks/task_e_6866ba6e7b248332b55f8ade0277a699