### PR TITLE
Add price masking on inputs

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -36,3 +36,16 @@ function formatarDataHoraISO(iso) {
   if (!iso) return '';
   return new Date(iso).toLocaleString('pt-BR');
 }
+
+// Mascara campos de preço permitindo apenas dígitos e
+// exibindo o valor formatado em reais conforme a digitação
+function mascararPrecoInput(event) {
+  const input = event.target;
+  const digits = input.value.replace(/\D/g, '');
+  const valor = parseFloat(digits) / 100;
+  const formatador = new Intl.NumberFormat('pt-BR', {
+    style: 'currency',
+    currency: 'BRL'
+  });
+  input.value = formatador.format(isNaN(valor) ? 0 : valor);
+}

--- a/views/cadastro.html
+++ b/views/cadastro.html
@@ -55,7 +55,7 @@
         <input type="number" name="quantidade" placeholder="Quantidade" min="0" required>
       </div>
       <div class="form-group">
-        <input type="text" name="preco" id="preco" placeholder="Preço Unitário (R$)" required>
+        <input type="text" name="preco" id="preco" placeholder="Preço Unitário (R$)" oninput="mascararPrecoInput(event)" required>
       </div>
       <div class="form-group">
         <label for="validade">Data de Validade:</label>
@@ -69,13 +69,6 @@
 
     <script src="/js/main.js"></script>
     <script>
-      const inputPreco = document.getElementById('preco');
-
-      inputPreco.addEventListener('input', () => {
-        let v = inputPreco.value.replace(/\D/g, '');
-        v = parseFloat(v) / 100;
-        inputPreco.value = formatarPreco(v);
-      });
 
       document.getElementById('formCadastro').addEventListener('submit', async (e) => {
         e.preventDefault();

--- a/views/conferencia_estoque.html
+++ b/views/conferencia_estoque.html
@@ -74,7 +74,7 @@
           <input type="number" id="edit-quantidade" placeholder="Quantidade">
         </div>
         <div class="form-group">
-          <input type="text" id="edit-preco" placeholder="Preço Unitário (R$)">
+          <input type="text" id="edit-preco" placeholder="Preço Unitário (R$)" oninput="mascararPrecoInput(event)">
         </div>
         <div class="form-group">
           <input type="date" id="edit-validade">
@@ -155,11 +155,6 @@
       document.getElementById('modalEdicao').style.display = 'none';
     }
 
-    document.getElementById('edit-preco').addEventListener('input', e => {
-      let v = e.target.value.replace(/\D/g, '');
-      v = parseFloat(v) / 100;
-      e.target.value = formatarPreco(v);
-    });
 
     document.getElementById('formEditar').addEventListener('submit', async (e) => {
       e.preventDefault();

--- a/views/quebras.html
+++ b/views/quebras.html
@@ -34,7 +34,7 @@
         <input type="number" name="quantidade" placeholder="Quantidade Quebrada" required>
       </div>
       <div class="form-group">
-        <input type="text" name="valor_quebra" id="valor_quebra" placeholder="Valor Total da Quebra (R$)" required>
+        <input type="text" name="valor_quebra" id="valor_quebra" placeholder="Valor Total da Quebra (R$)" oninput="mascararPrecoInput(event)" required>
       </div>
       <div class="form-group">
         <button type="submit">Registrar Quebra</button>
@@ -55,11 +55,6 @@
         });
       }
 
-      document.getElementById('valor_quebra').addEventListener('input', e => {
-        let v = e.target.value.replace(/\D/g, '');
-        v = parseFloat(v) / 100;
-        e.target.value = formatarPreco(v);
-      });
 
       document.getElementById('formQuebra').addEventListener('submit', async (e) => {
         e.preventDefault();

--- a/views/saidas.html
+++ b/views/saidas.html
@@ -34,7 +34,7 @@
         <input type="number" name="quantidade" placeholder="Quantidade Vendida" required>
       </div>
       <div class="form-group">
-        <input type="text" name="valor_saida" id="valor_saida" placeholder="Valor Total da Venda (R$)" required>
+        <input type="text" name="valor_saida" id="valor_saida" placeholder="Valor Total da Venda (R$)" oninput="mascararPrecoInput(event)" required>
       </div>
       <div class="form-group">
         <button type="submit">Registrar Saída</button>
@@ -56,11 +56,6 @@
         });
       }
 
-      document.getElementById('valor_saida').addEventListener('input', e => {
-        let v = e.target.value.replace(/\D/g, '');
-        v = parseFloat(v) / 100;
-        e.target.value = formatarPreco(v);
-      });
 
       document.getElementById('formSaida').addEventListener('submit', async (e) => {
         e.preventDefault();


### PR DESCRIPTION
## Summary
- add `mascararPrecoInput` helper on the global script
- apply the new mask in Cadastro, Quebras, Saídas and modal edit

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866bf027fc0833297b234af6dcf0217